### PR TITLE
Add benchmark

### DIFF
--- a/benchmark/kiriban_getter.rb
+++ b/benchmark/kiriban_getter.rb
@@ -24,6 +24,11 @@ module KiribanBenchmark
       self.abs.to_s.length
     end
 
+    def digit_3
+      return 1 if self.zero?
+      Math.log10(self.abs).to_i + 1
+    end
+
     alias_method :digit, :digit_2
 
     # legacy
@@ -81,6 +86,7 @@ Benchmark.ips do |x|
 
   x.report("digit_1 (legacy)") { rand_num.digit_1 }
   x.report("digit_2 (v0.1.0)") { rand_num.digit_2 }
+  x.report("digit_3")          { rand_num.digit_3 }
 
   x.compare!
 end

--- a/spec/kiriban_getter_spec.rb
+++ b/spec/kiriban_getter_spec.rb
@@ -52,6 +52,7 @@ describe KiribanGetter do
     using RSpec::Parameterized::TableSyntax
 
     where(:number, :expected) do
+      0    | 1
       1    | 1
       10   | 2
       11   | 2


### PR DESCRIPTION
```
Warming up --------------------------------------
    digit_1 (legacy)    74.173k i/100ms
    digit_2 (v0.1.0)    81.742k i/100ms
             digit_3    82.750k i/100ms
Calculating -------------------------------------
    digit_1 (legacy)      1.168M (± 7.9%) i/s -      5.785M in   4.999778s
    digit_2 (v0.1.0)      1.357M (± 5.1%) i/s -      6.785M in   5.012696s
             digit_3      1.366M (± 5.8%) i/s -      6.868M in   5.046705s

Comparison:
             digit_3:  1365551.2 i/s
    digit_2 (v0.1.0):  1357174.5 i/s - same-ish: difference falls within error
    digit_1 (legacy):  1168412.5 i/s - 1.17x slower
```

digit_3(`Math.log10`) vs digit_2 (`to_s.length`) : same-ish: difference falls within error