### PR TITLE
Speed up Integer#digit

### DIFF
--- a/benchmark/kiriban_getter.rb
+++ b/benchmark/kiriban_getter.rb
@@ -29,6 +29,14 @@ module KiribanBenchmark
       Math.log10(self.abs).to_i + 1
     end
 
+    def digit_4
+      Math.log10(self.abs).to_i + 1
+    rescue FloatDomainError
+      # Math.log10(0).to_i
+      # #=> FloatDomainError: -Infinity
+      1
+    end
+
     alias_method :digit, :digit_2
 
     # legacy
@@ -87,6 +95,7 @@ Benchmark.ips do |x|
   x.report("digit_1 (legacy)") { rand_num.digit_1 }
   x.report("digit_2 (v0.1.0)") { rand_num.digit_2 }
   x.report("digit_3")          { rand_num.digit_3 }
+  x.report("digit_4")          { rand_num.digit_4 }
 
   x.compare!
 end

--- a/benchmark/kiriban_getter.rb
+++ b/benchmark/kiriban_getter.rb
@@ -1,7 +1,7 @@
 require "benchmark/ips"
 
 def rand_num
-  rand(1000000)
+  rand(-10_000_000..10_000_000)
 end
 
 module KiribanBenchmark

--- a/benchmark/kiriban_getter.rb
+++ b/benchmark/kiriban_getter.rb
@@ -37,7 +37,7 @@ module KiribanBenchmark
       1
     end
 
-    alias_method :digit, :digit_2
+    alias_method :digit, :digit_4
 
     # legacy
     def kuraiban_1?

--- a/lib/kiriban_getter.rb
+++ b/lib/kiriban_getter.rb
@@ -24,7 +24,11 @@ module KiribanGetter
     alias_method :monodigit?, :zorome?
 
     def digit
-      self.abs.to_s.length
+      Math.log10(self.abs).to_i + 1
+    rescue FloatDomainError
+      # Math.log10(0).to_i
+      # #=> FloatDomainError: -Infinity
+      1
     end
 
     def kiriban?


### PR DESCRIPTION
```
Warming up --------------------------------------
    digit_1 (legacy)    60.395k i/100ms
    digit_2 (v0.1.0)    70.661k i/100ms
             digit_3    73.059k i/100ms
             digit_4    77.495k i/100ms
Calculating -------------------------------------
    digit_1 (legacy)      1.001M (± 5.5%) i/s -      5.013M in   5.023945s
    digit_2 (v0.1.0)      1.185M (± 6.4%) i/s -      5.936M in   5.031353s
             digit_3      1.270M (±10.4%) i/s -      6.283M in   5.050293s
             digit_4      1.468M (± 8.3%) i/s -      7.285M in   5.007498s

Comparison:
             digit_4:  1467584.4 i/s
             digit_3:  1269908.5 i/s - same-ish: difference falls within error
    digit_2 (v0.1.0):  1184810.6 i/s - 1.24x slower
    digit_1 (legacy):  1000996.2 i/s - 1.47x slower

```