### PR TITLE
Stop `gem update --system`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - 2.5
   - ruby-head
 before_install:
-  - gem update --system --no-document
   - gem install bundler --no-document
 cache: bundler
 before_script:


### PR DESCRIPTION
rubygems v3+ requires MRI 2.3+
https://rubygems.org/gems/rubygems-update/versions/3.0.0

So build is failed on MRI < 2.3